### PR TITLE
Upload task didn't get removed after uploaded an attachment

### DIFF
--- a/MessagingApp/View Model/MessageViewModel.swift
+++ b/MessagingApp/View Model/MessageViewModel.swift
@@ -286,6 +286,9 @@ class MessageViewModel: ObservableObject {
                     case .failure(let error):
                         print("Failed to upload file: \(error)")
                     }
+                    DispatchQueue.main.async {
+                        self.removeAttachmentFromUploadTask(attachmentIdentifier: file.identifier)
+                    }
                     dispatchGroup.leave()
                 }
                 


### PR DESCRIPTION
Learn more here: https://trello.com/c/YSriehQG/23-bug-upload-task-remained-in-memory-after-uploading-completed

Bug: Task remained in memory after uploading