### PR TITLE
Apply sound notification only when currently using the app.

### DIFF
--- a/MessagingApp/MessagingAppApp.swift
+++ b/MessagingApp/MessagingAppApp.swift
@@ -65,12 +65,14 @@ extension AppDelegate: MessagingDelegate {
     }
     
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-      let dataDict: [String: String] = ["token": fcmToken ?? ""]
-      NotificationCenter.default.post(
-        name: Notification.Name("FCMToken"),
-        object: nil,
-        userInfo: dataDict
-      )
+        if let fcmToken {
+            let dataDict: [String: String] = ["token": fcmToken]
+            NotificationCenter.default.post(
+                name: Notification.Name("FCMToken"),
+                object: nil,
+                userInfo: dataDict
+            )
+        }
     }
 }
 
@@ -82,7 +84,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        completionHandler([.sound, .banner, .badge, .list])
+        completionHandler([.sound])
     }
     
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {


### PR DESCRIPTION
Learn more here: https://trello.com/c/oZezkYZK/8-no-push-notification

Currently, when receiving notifications, there are stored in notification center and pop up even though the user already the messages. So, only sound notifications are necessary when the users are currently using the app. 